### PR TITLE
omniauth sso controller tests 100% coverage

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -10,10 +10,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
           flash[:notice] = "Please use a @colgate.edu email address to log in."
           redirect_to root_path
         end
-      else
-        email = request.env['omniauth.auth'].info.email
-        flash[:warning] = "No user #{email} configured; contact the administrator"
-        redirect_to root_path and return
       end
   end
 end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require 'login_helper'
+require 'capybara/rails'
+require 'simplecov'
+SimpleCov.start
+#As a user, so that I can be assured only Colgate-affiliates can use the marketplace, I want only colgate emails to be able to list items.
+
+describe OmniauthCallbacksController, type: :feature do
+    OmniAuth.config.test_mode = true
+
+it 'should let me log in as aknox@colgate.edu' do 
+    login
+    u = User.find(1)
+    expect(u.email).to eq("test@colgate.edu") #hits successful login path!
+    visit root_path
+    expect(page).to have_content("Logged in as test@colgate.edu")
+    expect(page).to have_content("List an item")
+end
+
+it 'should not let me log in as test@test.com' do
+    #I know this is ugly, but I wasn't sure how to change email to non-colgate from rails_helper.
+      OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+      :provider => 'google_oauth2',
+      :uid => '1',
+      :info => {
+        :email => "test@testcom"
+      },
+      :credentials => {
+        :token => "token",
+        :secret => "secret"
+      }})
+      
+    login
+    expect(page).to have_content("Please use a @colgate.edu email address to log in.")
+    expect(page).to have_no_content("List an item")
+end
+
+
+
+ #OmniAuth.config.mock_auth[:google_oauth2] = :invalid_credentials
+
+end

--- a/spec/login_helper.rb
+++ b/spec/login_helper.rb
@@ -1,0 +1,5 @@
+def login
+  Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:google]
+  visit root_path
+  click_link 'Log in with Google SSO'
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,19 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+  :provider => 'google_oauth2',
+  :uid => '1',
+  :info => {
+    :email => "test@colgate.edu"
+  },
+  :credentials => {
+    :token => "token",
+    :secret => "secret"
+  }
+  # etc.
+})
+OmniAuth.config.test_mode = false
 end


### PR DESCRIPTION
Stub the SSO login so we don't need to rely on internet/3rd party in order to test if authentication processes work. Checks to be sure only a user with a colgate email can log in to the marketplace and have access to item creation button.